### PR TITLE
Refactored tests and refactored workouts

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -130,7 +130,7 @@ describe("/api/users/:user_id", () => {
 
 describe("/api/users/:user_id/workouts", () => {
     describe("GET", () => {
-        test("200: Returns a user with the corresponding workouts", () => {
+        test("200: Returns all workouts for a user given the user ID", () => {
             return request(app)
             .get("/api/users/673b26e3656d6301098761d0/workouts")
             .expect(200)
@@ -140,15 +140,16 @@ describe("/api/users/:user_id/workouts", () => {
                 workouts.forEach((workout) => {
                     expect(workout.user_id).toBe("673b26e3656d6301098761d0")
                     expect(workout).toHaveProperty("_id");
-                    expect(workout).toHaveProperty("exercise_names");
-                    expect(workout).toHaveProperty("difficulty_level");
-                    expect(workout).toHaveProperty("date_completed");
-                    expect(workout).toHaveProperty("duration_in_seconds");
-                    expect(workout).toHaveProperty("xp_earned");
-                    expect(workout.exercise_names).toBeInstanceOf(Array)
+                    expect(Array.isArray(workout.exercise_names)).toBe(true);
                     workout.exercise_names.forEach((exercise) => {
-                        expect(typeof exercise).toBe("string");
+                        expect(typeof exercise).toBe("string")
+                        const objectIdRegex = /^[a-fA-F0-9]{24}$/
+                        expect(objectIdRegex.test(exercise)).toBe(false)
                     })
+                    expect(typeof workout.difficulty_level).toBe("number");
+                    expect(typeof workout.date_completed).toBe("string");
+                    expect(typeof workout.duration_in_seconds).toBe("number");
+                    expect(typeof workout.xp_earned).toBe("number");
                 })
             })
         })
@@ -173,18 +174,18 @@ describe("/api/users/:user_id/workouts", () => {
 
 describe("/api/exercises/:exercise_id", () => {
     describe("GET", () => {
-        test("200: Returns an exercise", () => {
+        test("200: Returns an exercise with the corresponding ID", () => {
             return request(app)
             .get("/api/exercises/673b26e3656d6301098761ba")
             .expect(200)
             .then((response) => {
                 const exercise = response.body.exercise;
-                expect(exercise).toHaveProperty("_id");
-                expect(exercise).toHaveProperty("exercise_name")
-                expect(exercise).toHaveProperty("exercise_type")
-                expect(exercise).toHaveProperty("difficulty_level")
-                expect(exercise).toHaveProperty("target_muscle_group")
                 expect(exercise).toBeInstanceOf(Object)
+                expect(exercise._id).toBe("673b26e3656d6301098761ba");
+                expect(typeof exercise.exercise_name).toBe("string")
+                expect(typeof exercise.exercise_type).toBe("string")
+                expect(typeof exercise.difficulty_level).toBe("number")
+                expect(typeof exercise.target_muscle_group).toBe("string")
             })
         })
         test("400: Responds with a bad request message if ID is invalid", () => {

--- a/controllers/exercises-controller.js
+++ b/controllers/exercises-controller.js
@@ -1,4 +1,4 @@
-const { fetchExercise } = require("../models/exercises-model");
+const { fetchExerciseById: fetchExercise } = require("../models/exercises-model");
 
 
 function getExercise(request, response, next) {

--- a/database/test-data/workouts.js
+++ b/database/test-data/workouts.js
@@ -4,7 +4,10 @@ module.exports = [
   {
     _id: new ObjectId("673b26e3656d6301098761e0"),
     user_id: new ObjectId("673b26e3656d6301098761d0"), // Alice Johnson
-    exercise_names: ["Push-up", "Squat"],
+    exercise_ids: [
+      new ObjectId("673b26e3656d6301098761ba"), // Push-up
+      new ObjectId("673b26e3656d6301098761bb")  // Squat
+    ],
     difficulty_level: 1,
     date_completed: new Date("2024-11-20T08:00:00Z"),
     duration_in_seconds: 1800,
@@ -13,7 +16,9 @@ module.exports = [
   {
     _id: new ObjectId("673b26e3656d6301098761e1"),
     user_id: new ObjectId("673b26e3656d6301098761d1"), // Bob Smith
-    exercise_names: ["Pull-up"],
+    exercise_ids: [
+      new ObjectId("673b26e3656d6301098761bc") // Pull-up
+    ],
     difficulty_level: 3,
     date_completed: new Date("2024-11-19T07:30:00Z"),
     duration_in_seconds: 1200,
@@ -22,7 +27,10 @@ module.exports = [
   {
     _id: new ObjectId("673b26e3656d6301098761e2"),
     user_id: new ObjectId("673b26e3656d6301098761d2"), // Charlie Davis
-    exercise_names: ["Bench Press", "Plank"],
+    exercise_ids: [
+      new ObjectId("673b26e3656d6301098761bd"), // Bench Press
+      new ObjectId("673b26e3656d6301098761be")  // Plank
+    ],
     difficulty_level: 2,
     date_completed: new Date("2024-11-20T06:00:00Z"),
     duration_in_seconds: 1500,
@@ -31,7 +39,9 @@ module.exports = [
   {
     _id: new ObjectId("673b26e3656d6301098761e3"),
     user_id: new ObjectId("673b26e3656d6301098761d4"), // Evan Green
-    exercise_names: ["Deadlift"],
+    exercise_ids: [
+      new ObjectId("673b26e3656d6301098761bf"), // Deadlift
+    ],
     difficulty_level: 3,
     date_completed: new Date("2024-11-19T20:00:00Z"),
     duration_in_seconds: 2400,

--- a/models/exercises-model.js
+++ b/models/exercises-model.js
@@ -2,7 +2,7 @@ const { ObjectId } = require("mongodb");
 const { client, db } = require("../database/database-connection");
 const exerciseDb = db.collection("exercises")
 
-function fetchExercise(exerciseId) {
+function fetchExerciseById(exerciseId) {
     return client.connect().then(() => {
         return exerciseDb.findOne({_id: new ObjectId(exerciseId)})
     }).then((exercise) => {
@@ -13,4 +13,4 @@ function fetchExercise(exerciseId) {
     })
 }
 
-module.exports = { fetchExercise }
+module.exports = { fetchExerciseById }


### PR DESCRIPTION
Workouts now stores exercise_ids instead of exercise_names in the database, but GET /api/users/:user_id/workouts still gives an object with exercise_names instead of exercise_ids.